### PR TITLE
Add implementation files to package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(EXTRA_FONTS_DIR ${SOURCE_DIR}/misc/fonts)
 
 set(SOURCE_FILES ${SOURCE_DIR}/imgui_draw.cpp
                  ${SOURCE_DIR}/imgui.cpp
-                 ${SOURCE_DIR}/imgui_demo.cpp
                  ${SOURCE_DIR}/imgui_widgets.cpp)
 set(HEADER_FILES ${SOURCE_DIR}/imconfig.h
                  ${SOURCE_DIR}/imgui_internal.h

--- a/conanfile.py
+++ b/conanfile.py
@@ -46,5 +46,5 @@ class IMGUIConan(ConanFile):
         cmake.install()
 
     def package_info(self):
-        self.cpp_info.srcdirs = ["misc/bindings", ]
+        self.cpp_info.srcdirs = ["misc", ]
         self.cpp_info.libs = tools.collect_libs(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class IMGUIConan(ConanFile):
     topics = ("conan", "imgui", "gui", "graphical")
     license = "MIT"
     exports = ["LICENSE.md"]
-    exports_sources = ["CMakeLists.txt", "imgui_demo.h", "imgui_demo.cpp"]
+    exports_sources = ["CMakeLists.txt", ]
     generators = "cmake"
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "fPIC": [True, False]}
@@ -41,8 +41,10 @@ class IMGUIConan(ConanFile):
 
     def package(self):
         self.copy(pattern="LICENSE.txt", dst="licenses", src=self._source_subfolder)
+        self.copy(pattern="examples/imgui_impl_*", dst="misc/bindings", src=self._source_subfolder, keep_path=False)
         cmake = self._configure_cmake()
         cmake.install()
 
     def package_info(self):
+        self.cpp_info.srcdirs = ["misc/bindings", ]
         self.cpp_info.libs = tools.collect_libs(self)

--- a/test_package/test_package.cpp
+++ b/test_package/test_package.cpp
@@ -23,7 +23,7 @@ int main(int, char**)
         ImGui::Text("Hello, world!");
         ImGui::SliderFloat("float", &f, 0.0f, 1.0f);
         ImGui::Text("Application average %.3f ms/frame (%.1f FPS)", 1000.0f / io.Framerate, io.Framerate);
-        ImGui::ShowDemoWindow(NULL);
+        // ImGui::ShowDemoWindow(NULL); // Demo code is not compiled inside the library.
 
         ImGui::Render();
     }


### PR DESCRIPTION
Following question here (https://github.com/bincrafters/community/issues/679), this PR adds `imgui_impl_***` files to the package, so a consumer could do the following ([example using glfw + opengl3](https://github.com/ocornut/imgui/blob/v1.66/examples/example_glfw_opengl3/main.cpp)):

conanfile.txt
```ini
[requires]
imgui/1.66@bincrafters/stable
glfw/3.2.1@bincrafters/stable
glew/2.1.0@bincrafters/stable

[generators]
cmake
```

CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.13)
project(example)

include(${CMAKE_CURRENT_BINARY_DIR}/conanbuildinfo.cmake)
conan_basic_setup(TARGETS)

add_definitions("-DIMGUI_IMPL_OPENGL_LOADER_GLEW")

add_executable(example main.cpp
        ${CONAN_SRC_DIRS_IMGUI}/imgui_impl_glfw.cpp
        ${CONAN_SRC_DIRS_IMGUI}/imgui_impl_opengl3.cpp)
target_include_directories(example PRIVATE ${CONAN_SRC_DIRS_IMGUI})
target_link_libraries(example CONAN_PKG::imgui CONAN_PKG::glfw CONAN_PKG::glew)
```

main.cpp
```
>> Copy from: https://github.com/ocornut/imgui/blob/v1.66/examples/example_glfw_opengl3/main.cpp
>> remove ImGui::ShowDemoWindow call as it isn't compiled inside the package
```

